### PR TITLE
fix(Auth): resolve login redirect race condition & invalid date crash

### DIFF
--- a/src/features/Auth/components/LoginForm.tsx
+++ b/src/features/Auth/components/LoginForm.tsx
@@ -112,8 +112,9 @@ const LoginForm: React.FC<LoginFormProps> = ({ onSwitchToRegister, onForgotPassw
         duration: 3000,
       });
 
-      const from = location.state?.from?.pathname || '/app';
-      navigate(from, { replace: true });
+      const from = location.state?.from?.pathname;
+      const safeTo = !from || from.startsWith('/auth') || from === '/' ? '/app' : from;
+      navigate(safeTo, { replace: true });
     } catch (error) {
       console.error('❌ Login error:', error);
       const firebaseError = error as FirebaseError;

--- a/src/features/Auth/hooks/useAuth.ts
+++ b/src/features/Auth/hooks/useAuth.ts
@@ -70,32 +70,10 @@ export const useAuth = (): AuthContextData => {
   }, []);
 
   useEffect(() => {
-    const checkAuthState = async () => {
-      try {
-        const currentUser = authService.getCurrentUser();
-        let user: BelroseUserProfile | null = null;
-
-        if (currentUser) {
-          // Check initial state, still need to merge profile
-          user = await fetchAndMergeProfile(currentUser);
-        }
-
-        setAuthState({
-          user,
-          loading: false,
-        });
-      } catch (error) {
-        console.error('Error checking auth state:', error);
-        setAuthState({
-          user: null,
-          loading: false,
-        });
-      }
-    };
-
     if (authService.onAuthStateChanged) {
       // The listener handles real-time auth changes
       const unsubscribe = authService.onAuthStateChanged(async (user: FirebaseAuthUser | null) => {
+        setAuthState(prev => ({ ...prev, loading: true }));
         let mergedUser: BelroseUserProfile | null = null;
 
         if (user) {
@@ -112,8 +90,6 @@ export const useAuth = (): AuthContextData => {
       return () => {
         unsubscribe();
       };
-    } else {
-      checkAuthState();
     }
   }, [fetchAndMergeProfile]); // Depend on fetchAndMergeProfile
 
@@ -123,11 +99,6 @@ export const useAuth = (): AuthContextData => {
       setAuthState(prev => ({ ...prev, loading: true }));
 
       await authService.signOut();
-
-      setAuthState({
-        user: null,
-        loading: false,
-      });
     } catch (error) {
       console.error('Sign out error:', error);
       setAuthState(prev => ({ ...prev, loading: false }));

--- a/src/features/HealthProfile/utils/fhirGroupingUtils.ts
+++ b/src/features/HealthProfile/utils/fhirGroupingUtils.ts
@@ -598,14 +598,18 @@ function resolveRecordDate(record: FileObject): string | undefined {
   const raw = record.belroseFields?.completedDate || record.createdAt || record.uploadedAt;
   if (!raw) return undefined;
 
-  // Firestore Timestamps have a toDate() method
   if (typeof (raw as any).toDate === 'function') {
     return (raw as any).toDate().toISOString();
   }
 
-  // Plain string or number
   if (typeof raw === 'string' || typeof raw === 'number') {
-    return new Date(raw).toISOString();
+    const date = new Date(raw);
+    if (isNaN(date.getTime())) {
+      console.warn('⚠️ resolveRecordDate: invalid date value on record', record.id, raw);
+      return undefined;
+    }
+
+    return date.toISOString();
   }
 
   return undefined;


### PR DESCRIPTION
Fixes two bugs found during testing.

#388 - Login redirect race condition
After logging out and back in, users were sometimes redirected back to /auth instead of the app. Two root causes:

useAuth was running checkAuthState (manual sync check) alongside onAuthStateChanged (the real-time listener), creating a race where stale null user state could win
The onAuthStateChanged callback wasn't setting loading: true before its async Firestore/token calls, so ProtectedRoute saw user: null, loading: false during the gap and redirected

Fix: removed checkAuthState entirely, made onAuthStateChanged the single source of truth, and set loading: true immediately when the listener fires. Also added a guard in LoginForm so from paths starting with /auth always fall back to /app.

#471 - FHIR date crash
resolveRecordDate was calling .toISOString() on potentially invalid Date objects, crashing the entire HealthProfile page with RangeError: Invalid time value.

Fix: added isNaN(date.getTime()) guard before calling .toISOString(), with a console warning to surface which record has the bad data.

Testing: Reproduced both bugs locally and confirmed fixed. Tested logout → immediate re-login with same account and cross-account login.