### PR TITLE
Fix/manage access bugs

### DIFF
--- a/src/features/Permissions/components/ui/PermissionUserCard.tsx
+++ b/src/features/Permissions/components/ui/PermissionUserCard.tsx
@@ -6,7 +6,7 @@ import { UserBadge } from '@/features/Users/components/ui/UserBadge';
 import { BelroseUserProfile, FileObject } from '@/types/core';
 import { TrusteeEntry } from '@/features/Trustee/hooks/useRecordTrustees';
 import * as Tooltip from '@radix-ui/react-tooltip';
-import { ChevronDown, ChevronUp, ShieldCheck } from 'lucide-react';
+import { AlertCircle, ChevronDown, ChevronUp, ShieldCheck, ShieldOff } from 'lucide-react';
 import { TrustLevel } from '@/features/Trustee/services/trusteeRelationshipService';
 
 // ============================================================================
@@ -20,35 +20,87 @@ const TRUST_LEVEL_CONFIG: Record<TrustLevel, { label: string; badgeClass: string
 };
 
 // ============================================================================
+// HELPERS
+// ============================================================================
+
+function hasTrusteeRecordAccess(trusteeId: string, record: FileObject): boolean {
+  return (
+    record.owners?.includes(trusteeId) ||
+    record.administrators?.includes(trusteeId) ||
+    record.viewers?.includes(trusteeId) ||
+    false
+  );
+}
+
+// ============================================================================
 // TRUSTEE MINI CARD (inside the expand panel)
 // ============================================================================
 
 interface TrusteeMiniCardProps {
   entry: TrusteeEntry;
+  record: FileObject;
 }
 
-const TrusteeMiniCard: React.FC<TrusteeMiniCardProps> = ({ entry }) => {
+const TrusteeMiniCard: React.FC<TrusteeMiniCardProps> = ({ entry, record }) => {
   const config = TRUST_LEVEL_CONFIG[entry.trustLevel];
   const profile = entry.trusteeProfile;
   const displayName = profile?.displayName ?? profile?.email ?? entry.trusteeId;
+  const hasAccess = hasTrusteeRecordAccess(entry.trusteeId, record);
 
   return (
-    <div className="flex items-center gap-3 px-3 py-2 rounded-lg bg-white border border-blue-100">
+    <div
+      className={`flex items-center gap-3 px-3 py-2 rounded-lg border ${
+        hasAccess ? 'bg-white border-blue-100' : 'bg-amber-50 border-amber-200'
+      }`}
+    >
       {/* Avatar */}
-      <div className="w-7 h-7 rounded-full bg-teal-500 flex items-center justify-center text-white text-xs font-bold flex-shrink-0">
+      <div
+        className={`w-7 h-7 rounded-full flex items-center justify-center text-white text-xs font-bold flex-shrink-0 ${
+          hasAccess ? 'bg-teal-500' : 'bg-amber-400'
+        }`}
+      >
         {displayName.slice(0, 2).toUpperCase()}
       </div>
+
       {/* Name */}
       <div className="flex-1 min-w-0">
-        <p className="text-xs font-semibold truncate">{displayName}</p>
+        <p className={`text-xs font-semibold truncate ${!hasAccess ? 'text-amber-900' : ''}`}>
+          {displayName}
+        </p>
         {profile?.email && <p className="text-xs text-gray-400 truncate">{profile.email}</p>}
       </div>
-      {/* Trust level badge */}
-      <span
-        className={`text-xs font-semibold px-2 py-0.5 rounded-full border ${config.badgeClass}`}
-      >
-        {config.label}
-      </span>
+
+      {/* Badges */}
+      <div className="flex items-center gap-1.5 flex-shrink-0">
+        {!hasAccess && (
+          <Tooltip.Provider>
+            <Tooltip.Root>
+              <Tooltip.Trigger asChild>
+                <span className="inline-flex items-center gap-1 text-xs font-semibold px-2 py-0.5 rounded-full border bg-amber-100 text-amber-800 border-amber-400">
+                  <ShieldOff className="w-3 h-3" />
+                  Access Missing
+                </span>
+              </Tooltip.Trigger>
+              <Tooltip.Portal>
+                <Tooltip.Content
+                  className="bg-gray-900 text-white rounded-lg px-3 py-2 text-xs max-w-xs shadow-xl z-50"
+                  sideOffset={5}
+                >
+                  This trustee relationship is active but access to this specific record is missing.
+                  <Tooltip.Arrow className="fill-gray-900" />
+                </Tooltip.Content>
+              </Tooltip.Portal>
+            </Tooltip.Root>
+          </Tooltip.Provider>
+        )}
+        <span
+          className={`text-xs font-semibold px-2 py-0.5 rounded-full border ${
+            hasAccess ? config.badgeClass : 'bg-gray-100 text-gray-500 border-gray-300'
+          }`}
+        >
+          {config.label}
+        </span>
+      </div>
     </div>
   );
 };
@@ -84,6 +136,11 @@ export const PermissionUserCard: React.FC<PermissionUserCardProps> = ({
 
   const isTrustee = !!trusteeEntry;
   const hasTrustees = trusteeList.length > 0;
+
+  // Count how many trustees in the list are missing record access — used in the toggle badge
+  const missingAccessCount = trusteeList.filter(
+    e => !hasTrusteeRecordAccess(e.trusteeId, record)
+  ).length;
 
   // ── Content slot: identity badges + trustee shield badge ──────────────────
 
@@ -138,9 +195,17 @@ export const PermissionUserCard: React.FC<PermissionUserCardProps> = ({
               e.stopPropagation();
               setExpanded(prev => !prev);
             }}
-            className="inline-flex items-center gap-1 text-xs font-semibold px-2 py-1 rounded-full border bg-complement-3/50 text-primary border-complement-3 hover:bg-complement-3/30 transition-colors"
+            className={`inline-flex items-center gap-1 text-xs font-semibold px-2 py-1 rounded-full border transition-colors ${
+              missingAccessCount > 0
+                ? 'bg-amber-100 text-amber-800 border-amber-400 hover:bg-amber-200'
+                : 'bg-complement-3/50 text-primary border-complement-3 hover:bg-complement-3/30'
+            }`}
           >
-            <ShieldCheck className="w-3 h-3" />
+            {missingAccessCount > 0 ? (
+              <AlertCircle className="w-3 h-3" />
+            ) : (
+              <ShieldCheck className="w-3 h-3" />
+            )}
             {trusteeList.length} {trusteeList.length === 1 ? 'Trustee' : 'Trustees'}
             {expanded ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />}
           </button>
@@ -167,12 +232,10 @@ export const PermissionUserCard: React.FC<PermissionUserCardProps> = ({
 
       {/* Expand panel — trustees of this trustor */}
       {hasTrustees && expanded && (
-        <div className="bg-supplement-3 px-3 py-2 space-y-2">
-          <p className="text-xs font-semibold mb-1">
-            Trustees with access via {userProfile?.firstName}:
-          </p>
+        <div className="bg-gray-50 px-3 py-2 space-y-2">
+          <p className="text-xs font-semibold mb-1">Trustees (via {userProfile?.firstName}):</p>
           {trusteeList.map(entry => (
-            <TrusteeMiniCard key={entry.trusteeId} entry={entry} />
+            <TrusteeMiniCard key={entry.trusteeId} entry={entry} record={record} />
           ))}
         </div>
       )}

--- a/src/features/Sharing/components/EncryptionAccessView.tsx
+++ b/src/features/Sharing/components/EncryptionAccessView.tsx
@@ -38,9 +38,14 @@ export interface AccessEntry {
 interface EncryptionAccessViewProps {
   record: FileObject;
   onBack?: () => void;
+  onSuccess?: () => void;
 }
 
-export const EncryptionAccessView: React.FC<EncryptionAccessViewProps> = ({ record, onBack }) => {
+export const EncryptionAccessView: React.FC<EncryptionAccessViewProps> = ({
+  record,
+  onBack,
+  onSuccess,
+}) => {
   const { user } = useAuth();
   const [accessEntries, setAccessEntries] = useState<AccessEntry[]>([]);
   const [loading, setLoading] = useState(true);
@@ -57,7 +62,10 @@ export const EncryptionAccessView: React.FC<EncryptionAccessViewProps> = ({ reco
   } = usePermissionFlow({
     recordId: record.id,
     recordTitle: (record.belroseFields?.title || record.fileName) ?? undefined,
-    onSuccess: () => fetchEncryptionAccess(),
+    onSuccess: () => {
+      fetchEncryptionAccess();
+      onSuccess?.();
+    },
   });
 
   const fetchEncryptionAccess = async () => {
@@ -253,7 +261,7 @@ export const EncryptionAccessView: React.FC<EncryptionAccessViewProps> = ({ reco
           </div>
           <UserSearch
             onUserSelect={user => setSelectedUserForGrant(user)}
-            excludeUserIds={accessEntries.map(e => e.userId)}
+            excludeUserIds={accessEntries.filter(e => e.wrappedKey?.isActive).map(e => e.userId)}
             placeholder="Search by name, email, or user ID..."
           />
           {selectedUserForGrant && (

--- a/src/features/ViewEditRecord/components/RecordFull.tsx
+++ b/src/features/ViewEditRecord/components/RecordFull.tsx
@@ -657,7 +657,11 @@ export const RecordFull: React.FC<RecordFullProps> = ({
       )}
 
       {viewMode === 'access' && (
-        <EncryptionAccessView record={record} onBack={handleBackToRecord} />
+        <EncryptionAccessView
+          record={record}
+          onBack={handleBackToRecord}
+          onSuccess={onRefreshRecord}
+        />
       )}
 
       {viewMode === 'credibility' && (

--- a/src/features/ViewEditRecord/components/RecordFull.tsx
+++ b/src/features/ViewEditRecord/components/RecordFull.tsx
@@ -501,7 +501,7 @@ export const RecordFull: React.FC<RecordFullProps> = ({
                   record={record}
                   triggerIcon={Ellipsis}
                   triggerClassName="p-2 text-white/80 hover:text-white hover:bg-white/20 rounded-lg transition-colors"
-                  showView={false} //Don't need view because we're already on view full record
+                  onView={viewMode !== 'record' ? handleBackToRecord : undefined}
                   onEdit={viewMode !== 'edit' ? handleEnterEditMode : undefined}
                   onVersion={viewMode !== 'versions' ? handleViewVersionHistory : undefined}
                   onSubject={viewMode !== 'subject' ? handleSubjectPage : undefined}


### PR DESCRIPTION
4 Different Fixes mainly related to Record Permissions/Encryption Access

1.) Problem: Menu in Record full would never show View Record. Made navigation back to the record view from within RecordFull confusing.

Fix: Changed recordMenu within recordFull that so that you can click back to record view from other components within RecordFull

---

2.) Problem: Changes on Encryption Access/Sharing screen can result in changes in Permissions but are not reflected right away on the separate Permissions component.

Fix: Added onSuccess prop to EncryptionAccessView so that it refreshes the whole record in RecordFull and updates PermissionsManager

---

3.) Problem: Could not add back people with Inactive keys on EncryptionAccessView

Fix: Changed exclusion criteria in EncryptionAccessView's UserSearch to only exclude people with active keys.

---

4.) Problem: On Permission Manager, a trustee were always listed as having access through the Trustor. This is inaccurate in the edge case that a trustee's access was removed (or never granted for some reason). 

Fix: Changed PermissionUserCard to check if the trustee has access. If not, it shows an alert saying the Trustee is missing access.